### PR TITLE
fix *current-cache-directory* parameter

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -19,7 +19,7 @@
      (parameter/c boolean?)]
 
     [*current-cache-directory*
-     (parameter/c path-string?)]
+     (parameter/c (and/c path-string? directory-exists?))]
 
     [*current-cache-keys*
      (parameter/c keys/c)]

--- a/private/with-cache.rkt
+++ b/private/with-cache.rkt
@@ -56,18 +56,14 @@
 (define (get-package-version)
   ((get-info '("with-cache")) 'version))
 
-(define null-dir (gensym 'uninitialized))
 (define no-keys (string->symbol (string-append "no-keys:" (get-package-version))))
 
 (define *use-cache?* (make-parameter #t))
 (define *with-cache-fasl?* (make-parameter #t))
-(define *current-cache-directory* (make-parameter null-dir))
+(define *current-cache-directory* (make-parameter (build-path (current-directory) "compiled")))
 (define *current-cache-keys* (make-parameter (list get-package-version)))
 
 (define-logger with-cache)
-
-(define (null-dir? x)
-  (eq? x null-dir))
 
 (define (no-keys? x)
   (eq? x no-keys))
@@ -75,18 +71,7 @@
 ;; -----------------------------------------------------------------------------
 
 (define (cachefile ps)
-  (if (not (null-dir? (*current-cache-directory*)))
-    (build-path (*current-cache-directory*) ps)
-    (let* ([cwd (current-directory)]
-           [compiled (build-path cwd "compiled")]
-           [wc (build-path compiled "with-cache")])
-      (cond
-       [(not (directory-exists? compiled))
-        (build-path cwd ps)]
-       [else
-        (unless (directory-exists? wc)
-          (make-directory wc))
-        (build-path wc ps)]))))
+  (build-path (*current-cache-directory*) ps))
 
 (define (with-cache cache-file
                     thunk

--- a/scribblings/with-cache.scrbl
+++ b/scribblings/with-cache.scrbl
@@ -140,7 +140,7 @@ The @racket[with-cache] function implements this pipeline and provides hooks for
   Note that byte strings written using @racket[s-exp->fasl] cannot be read by code running a different version of Racket.
 }
 
-@defparam[*current-cache-directory* cache-dir boolean? #:value "./compiled/with-cache"]{
+@defparam[*current-cache-directory* cache-dir (and/c path-string? directory-exists?) #:value (build-path (current-directory) "compiled")]{
   The value of this parameter is the prefix of paths returned by @racket[cachefile].
   Another good default is @racket[(find-system-path 'temp-dir)].
 }


### PR DESCRIPTION
re #14 , thanks for pointing out:

- the documentation was wrong
- `*current-cache-directory*` intentionally broke its own contract; the idea was it would CREATE the default directory the first time you call `cachefile`. That was a bad idea.


This PR
- fixes the documentation
- stops trying to create `*current-cache-directory*` if it doesn't exist
- makes `(build-path (current-directory) "compiled")` the default, and assumes Racket builds this directory

looks good?