### PR TITLE
cachefile: check that directory exists

### DIFF
--- a/private/with-cache.rkt
+++ b/private/with-cache.rkt
@@ -42,7 +42,7 @@
 )
 
 (require
-  (only-in racket/file file->value call-with-file-lock/timeout make-lock-file-name)
+  (only-in racket/file file->value call-with-file-lock/timeout make-lock-file-name make-directory*)
   (only-in racket/path path-only)
   (only-in racket/date date-display-format current-date date->string)
   (only-in racket/serialize serialize deserialize)
@@ -60,7 +60,7 @@
 
 (define *use-cache?* (make-parameter #t))
 (define *with-cache-fasl?* (make-parameter #t))
-(define *current-cache-directory* (make-parameter (build-path (current-directory) "compiled")))
+(define *current-cache-directory* (make-parameter (build-path (current-directory) "compiled" "with-cache")))
 (define *current-cache-keys* (make-parameter (list get-package-version)))
 
 (define-logger with-cache)
@@ -73,7 +73,7 @@
 (define (cachefile ps)
   (define ccd (*current-cache-directory*))
   (unless (directory-exists? ccd)
-    (make-directory ccd))
+    (make-directory* ccd))
   (build-path ccd ps))
 
 (define (with-cache cache-file

--- a/private/with-cache.rkt
+++ b/private/with-cache.rkt
@@ -71,7 +71,10 @@
 ;; -----------------------------------------------------------------------------
 
 (define (cachefile ps)
-  (build-path (*current-cache-directory*) ps))
+  (define ccd (*current-cache-directory*))
+  (unless (directory-exists? ccd)
+    (make-directory ccd))
+  (build-path ccd ps))
 
 (define (with-cache cache-file
                     thunk

--- a/scribblings/with-cache.scrbl
+++ b/scribblings/with-cache.scrbl
@@ -140,7 +140,7 @@ The @racket[with-cache] function implements this pipeline and provides hooks for
   Note that byte strings written using @racket[s-exp->fasl] cannot be read by code running a different version of Racket.
 }
 
-@defparam[*current-cache-directory* cache-dir (and/c path-string? directory-exists?) #:value (build-path (current-directory) "compiled")]{
+@defparam[*current-cache-directory* cache-dir (and/c path-string? directory-exists?) #:value (build-path (current-directory) "compiled" "with-cache")]{
   The value of this parameter is the prefix of paths returned by @racket[cachefile].
   Another good default is @racket[(find-system-path 'temp-dir)].
 }


### PR DESCRIPTION
Stop assuming `(*current-cache-directory*)` exists.

Most of the time it will, but sometimes not (closes #16).