### PR TITLE
Fix a test

### DIFF
--- a/private/with-cache.rkt
+++ b/private/with-cache.rkt
@@ -336,7 +336,7 @@
     (check-not-equal? v0 x)
     (check-equal? ((read/keys id good-keys equal?) v0) x)
 
-    (check-false ((read/keys id bad-keys equal?) v0) x))
+    (check-false ((read/keys id bad-keys equal?) v0)))
 
   (test-case "keys->vals"
     (define v0 #t)


### PR DESCRIPTION
check-false consumes only one argument. The second argument here is
likyly unintentional from copy-and-paste of the previous test.